### PR TITLE
ci: pin github action node version to 18.12.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: setup node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: "18.12.1"
 
       - name: install pnpm
         run: npm i pnpm@latest -g


### PR DESCRIPTION
## Description
- pin github action node version to 18.12.1