### PR TITLE
fix: remove react as a dependency

### DIFF
--- a/.changeset/smooth-candles-invite.md
+++ b/.changeset/smooth-candles-invite.md
@@ -1,0 +1,5 @@
+---
+"@revenuehero/sdk-react": patch
+---
+
+Removed react dependency

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -39,13 +39,10 @@
     "react": "^16 || ^17 || ^18",
     "react-dom": "^16 || ^17 || ^18"
   },
-  "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/revenuehero/sdk.git"
+    "url": "git+https://github.com/revenuehero/sdk.git",
+    "directory": "packages/react"
   },
   "bugs": {
     "url": "https://github.com/revenuehero/sdk/issues"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,10 @@ importers:
   packages/react:
     dependencies:
       react:
-        specifier: ^18.2.0
+        specifier: ^16 || ^17 || ^18
         version: 18.2.0
       react-dom:
-        specifier: ^18.2.0
+        specifier: ^16 || ^17 || ^18
         version: 18.2.0(react@18.2.0)
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Description
- The package allows react 16 || 17 || 18
- somehow we had react 18 as hard dependency, which will make package managers throw errors in <18 projects